### PR TITLE
Update sling.service

### DIFF
--- a/sling.service
+++ b/sling.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=SlingBox Server Service
-After=multi-user.target
+After=systemd-hostnamed.service
+Wants=systemd-hostnamed.service
+
 
 [Service]
 Type=idle


### PR DESCRIPTION
I changed the After and Wants to wait for systemd-hostnamed.service to be up so that slingbox discovery works at reboot.