### PR TITLE
Format and add M2-specific video source information

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -38,13 +38,16 @@ password=YourSlingboxPassword
 ; Audio Bit Rate. Valid Options 16, 20, 32, 40, 48, 64, 96 Default 32
 ;AudioBitRate=32
 
-; Video Source  0, 1, 2, 3 depending on your hardware corrosponds to one of
-;Composite, Component, HDMI or Tuner.
-;ProHD 0=Tuner, 1=composite 2=svideo 3=component
-;Solo, M1 0=composite 1=Svideo 2=component
-;500  0=composite, 1=component, 2=HDMI
-; If you don't set this the code will use the last configired input
-; I recommend setting this value. If not set correctly you'll often only see a black screen. 
+; Video Source  0, 1, 2, 3 depending on your hardware corresponds to one of
+; Composite, Component, S-Video, HDMI or Tuner.
+;  ProHD: 0=Tuner      1=Composite  2=S-Video   3=Component
+;Solo/M1: 0=Composite  1=S-Video    2=Component
+;    500: 0=Composite  1=Component  2=HDMI
+;     M2: 0=Composite  1=Component
+; If you don't set this, the code will use the last configured input
+; I recommend setting this value. If not set correctly, you'll often only see a black screen.
+; Note: Setting invalid options may cause unexpected hardware behavior. For example, setting
+;  2 or 3 for M2 hardware causes it to reboot.
 VideoSource = 1
 
 [SERVER]


### PR DESCRIPTION
Helped a friend set up his M2 tonight. I've added the M2-specific config information. Additionally, a note about setting incorrect video source settings, and formatted the section to fix a spelling error as well as format into a table-like structure for readability.