### PR TITLE
Made systemd unit more portable, created init script for OpenRC-based systems

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,7 @@ You'll need a working Python3 interpreter to get going. Comes pre-installed on t
     sudo pip install netifaces
     
     copy "slingbox_server.py, config.ini and sling.service to /home/slingbox   
+    sudo chmod +x /home/slingbox/slingbox_server.py
 
     sudo cp sling.service /etc/systemd/system/.
  #   enable it

--- a/sling.service
+++ b/sling.service
@@ -8,7 +8,7 @@ User=slingbox
 WorkingDirectory=/home/slingbox
 StandardOutput=append:/tmp/sling.log
 StandardError=append:/tmp/sling.log
-ExecStart=/usr/bin/python -u slingbox_server.py 
+ExecStart=/usr/bin/env python -u slingbox_server.py 
 Restart=always
 
 [Install]

--- a/sling_openrc
+++ b/sling_openrc
@@ -1,0 +1,16 @@
+#!/sbin/openrc-run
+name="slinger"
+description="SlingBox Server Service"
+command_user="slingbox"
+directory="/home/${command_user}"
+export PYTHONUNBUFFERED=1
+command="${directory}/slingbox_server.py"
+output_log="/tmp/sling.log"
+error_log="/tmp/sling.log"
+pidfile="/run/${RC_SVCNAME}.pid"
+start_stop_daemon_args="--chdir $directory"
+supervisor="supervise-daemon"
+
+depend() {
+	after multi-user
+}

--- a/slingbox_server.py
+++ b/slingbox_server.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 try:
     assert sys.version_info >= (3,5)


### PR DESCRIPTION
Using env to call the Python executable from $PATH is generally a safer bet for portability than hard-coding the path, so I modified `sling.service` accordingly.
Also created a corresponding OpenRC script (`sling_openrc`) tested to work on Gentoo.  OpenRC users can drop this file in `/etc/init.d/` and mark both it and `/home/slingbox/slingbox_server.py` as executable to have an equivalent service.