### PR TITLE
Added parameter to configure remote commands delay after starting stream

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -53,6 +53,9 @@ password=YourSlingboxPassword
 ;  2 or 3 for M2 hardware causes it to reboot.
 VideoSource = 1
 
+;Configure delay before sending remote commands after starting the stream (when using ?channel=xx). Your mileage may vary on this. Defaults to 10 seconds.
+;RemoteDelay = 10.0
+
 [SERVER]
 ;local port number for the server to listen on for connections
 port=8080

--- a/slingbox_server.py
+++ b/slingbox_server.py
@@ -807,6 +807,7 @@ def streamer(maxstreams, config_fn, section_name, box_name, streamer_q, server_p
                 print('name, Bad E1: Password Missing characters')
                 continue             
         
+        remotedelay = float(slinginfo.get('RemoteDelay', 10.0))
         resolution = int(slinginfo.get('Resolution', 12 ))
         if resolution < 0 or resolution > 16 : 
             print(name, 'Invalid Resolution', resolution, 'Defaulting to 640x480')
@@ -943,7 +944,7 @@ def streamer(maxstreams, config_fn, section_name, box_name, streamer_q, server_p
                         if socket_ready : s_ctl.recv(8192)
                           
                     if StartChannel : 
-                        if curtime - startchanneltime > 10.0 :
+                        if curtime - startchanneltime > remotedelay :
                             StartChannel = send_start_channel(StartChannel, rccode)
                     
 


### PR DESCRIPTION
I had different experiences with the delay after the start stream sending remote commands (currently using 0.5 in my ProHD which is working really well). This is my first PR so happy to take comments on this.