### PR TITLE
fix condition for GET method

### DIFF
--- a/slingbox_server.py
+++ b/slingbox_server.py
@@ -1164,7 +1164,7 @@ def ConnectionManager(config_fn):
             if ( 'remote' in data.lower() and ('GET' in data or 'POST' in data) and    remoteenabled ) or ('.php' in data) and 'HTTP' in data:
                 print(ts(), ' RemoteControl connection from', str(client_address))
                 Thread(target=remote_control_stream, args=(connection, client_address, data, local_port)).start()           
-            elif 'GET' and 'HTTP' in data:
+            elif 'GET' in data and 'HTTP' in data:
                 start_uri = data.find('GET') + 3
                 end_uri = data.find('HTTP', start_uri)
                 uri = data[start_uri:end_uri]


### PR DESCRIPTION
The test `'GET' and 'HTTP' in data` interprets `'GET'` as `True` and is valid for any HTTP connection not matching the previous comparison. This manifests itself e.g. when doing a HEAD request. Though this would probably not happen during usual use of the program.