### PR TITLE
fix SENDIRKEYCODES api

### DIFF
--- a/slingbox_server.py
+++ b/slingbox_server.py
@@ -1215,7 +1215,7 @@ def ConnectionManager(config_fn):
  #               connection.send(SendData(GetFile(data)))
  #               connection = closeconn(connection)
  #               continue
-            elif data.startswith('SENDIRKEYCODES=') :
+            elif data.startswith('SENDIRKEYCODES') :
                 SendIRKeycodes(data)
                 connection = closeconn(connection)
                 continue


### PR DESCRIPTION
Extraneous `=` caused the `SENDIRKEYCODES` work only with the code `-1`, there was no way to specify a Slingbox ID.